### PR TITLE
Fix: ansible-galaxy minus to underscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: 
+python:
   - "2.7"
   - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.wtd-bash
+  - ln -s  $PWD ../while_true_do.wtd-bash
 
 # Run the tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while_true_do.wtd-bash
+  - ln -s  $PWD ../while_true_do.wtd_bash
 
 # Run the tests
 script:

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ Deploying customizations for bash is a regular task. To have the same look and f
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/wtd-bash)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/wtd_bash)
 
 ```
-ansible-galaxy install while_true_do.wtd-bash
+ansible-galaxy install while_true_do.wtd_bash
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-wtd-bash)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-wtd-bash.git while_true_do.wtd-bash
+git clone https://github.com/while-true-do/ansible-role-wtd-bash.git while_true_do.wtd_bash
 ```
 
 ## Requirements
@@ -61,7 +61,7 @@ Simple Example:
 ```yaml
 - hosts: servers
   roles:
-    - { role: while_true_do.wtd-bash }
+    - { role: while_true_do.wtd_bash }
 ```
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ Deploying customizations for bash is a regular task. To have the same look and f
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do/wtd-bash)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do/wtd-bash)
 
 ```
-ansible-galaxy install while-true-do.wtd-bash
+ansible-galaxy install while_true_do.wtd-bash
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-wtd-bash)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-wtd-bash.git while-true-do.wtd-bash
+git clone https://github.com/while-true-do/ansible-role-wtd-bash.git while_true_do.wtd-bash
 ```
 
 ## Requirements
@@ -61,7 +61,7 @@ Simple Example:
 ```yaml
 - hosts: servers
   roles:
-    - { role: while-true-do.wtd-bash }
+    - { role: while_true_do.wtd-bash }
 ```
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/while-true-do/ansible-role-wtd-bash.svg?branch=master)](https://travis-ci.org/while-true-do/ansible-role-wtd-bash)
 
 # Ansible Role: wtd-bash
-| A role to deploy the bash customizations from wtd 
+| A role to deploy the bash customizations from wtd
 
 The following customizations will be deployed:
 

--- a/docs/COMMIT_TEMPLATE.md
+++ b/docs/COMMIT_TEMPLATE.md
@@ -32,7 +32,7 @@ Further paragraphs come after blank lines, if needed.
  - Bullet points are okay, too.
  - A hyphen or asterisk is used for the bullet, preceded by a single space and can
    be wrapped around.
-   
+
  - Resolves: #12
  - See also: #33, #44
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 | While True Do Contribution Guidelines
 
 
-This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/docs/) to check the latest version.
+This guideline is only a snapshot. Please have a look [here](https://github.com/while-true-do/community/blob/master/docs/CONTRIBUTING.md) to check the latest version.
 
 ## Welcome
 
@@ -17,7 +17,7 @@ In this document you can find some guidance, how you can take care of bugs, subm
 -   [Submit Changes and Pull Requests](#Submit-Changes-and-Pull-Requests)
 -   [Documentation](#Documentation)
 -   [Testing](#Testing)
-  
+
 ## Resources
 
 -   Documents: <https://github.com/while-true-do/community/>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ dependencies:
   - { role: while_true_do.bash }
 
 galaxy_info:
+  role_name: wtd_bash
   author: while-true-do.org
   description: A very simple role to deploy some bash packages.
   company: while-true-do.org

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   description: A very simple role to deploy some bash packages.
   company: while-true-do.org
 
-    github_branch: master
+  github_branch: master
   license: BSD
 
   min_ansible_version: 2.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,14 +1,13 @@
 dependencies:
-  - { role: while-true-do.git }
-  - { role: while-true-do.bash }
+  - { role: while_true_do.git }
+  - { role: while_true_do.bash }
 
 galaxy_info:
   author: while-true-do.org
   description: A very simple role to deploy some bash packages.
   company: while-true-do.org
 
-  issue_tracker_url: https://github.com/while-true-do/ansible-role-wtd-bash/issues
-  github_branch: master
+    github_branch: master
   license: BSD
 
   min_ansible_version: 2.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 # from galaxy
-- src: while-true-do.git
-- src: while-true-do.bash
+- src: while_true_do.git
+- src: while_true_do.bash

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while_true_do.wtd-bash
+    - while_true_do.wtd_bash

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.wtd-bash
+    - while_true_do.wtd-bash

--- a/update-meta-files.sh
+++ b/update-meta-files.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Description:
-#   update-skeleton.sh is a very minimal script to update the skeleton with 
-#   some additional content from while-true-do.org. It will not remove files, 
+#   update-skeleton.sh is a very minimal script to update the skeleton with
+#   some additional content from while-true-do.org. It will not remove files,
 #   you created. Replacement must be acknowledged.
 
 function usage {
@@ -90,7 +90,7 @@ function update_all {
 }
 
 while getopts 'admst' opts; do
-  
+
   case "${opts}" in
     a) update_all ;;
     d) update_docs ;;


### PR DESCRIPTION
# Fix: ansible-galaxy minus to underscore

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

## Reference

 - Resolves:
